### PR TITLE
Fixes edge case when `user_name` has uppercase or is too long

### DIFF
--- a/rag_app_sample_code/00_global_config.py
+++ b/rag_app_sample_code/00_global_config.py
@@ -25,7 +25,7 @@ import mlflow
 
 # By default, will use the current user name to create a unique UC catalog/schema & vector search endpoint
 user_email = spark.sql("SELECT current_user() as username").collect()[0].username
-user_name = user_email.split("@")[0].replace(".", "")
+user_name = user_email.split("@")[0].replace(".", "").lower()[:35]
 
 # COMMAND ----------
 


### PR DESCRIPTION
I ran into this issue when running the `01_validate_config_and_create_resources` notebook so I thought I'd add some fixes to help others avoid this error:
> InvalidParameterValue: Vector search endpoint name BlakeEKleinhans_vector_search must contain less than 50 characters, contain only lowercase alphanumeric characters, '_', '-' or '.', and start and end with an alphanumeric character.