### PR TITLE
Fix dash in catalog name and schema name

### DIFF
--- a/rag_app_sample_code/A_POC_app/databricks_docs_example/00_config.py
+++ b/rag_app_sample_code/A_POC_app/databricks_docs_example/00_config.py
@@ -95,11 +95,11 @@ data_pipeline_config = {
 # Names of the output Delta Tables tables & Vector Search index
 destination_tables_config = {
     # Staging table with the raw files & metadata
-    "raw_files_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_raw_files_bronze",
+    "raw_files_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_raw_files_bronze`",
     # Parsed documents
-    "parsed_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_parsed_docs_silver",
+    "parsed_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_parsed_docs_silver`",
     # Chunked documents that are loaded into the Vector Index
-    "chunked_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold",
+    "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
     "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
 }

--- a/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
@@ -88,11 +88,11 @@ data_pipeline_config = {
 # Names of the output Delta Tables tables & Vector Search index
 destination_tables_config = {
     # Staging table with the raw files & metadata
-    "raw_files_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_raw_files_bronze",
+    "raw_files_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_raw_files_bronze`",
     # Parsed documents
-    "parsed_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_parsed_docs_silver",
+    "parsed_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_parsed_docs_silver`",
     # Chunked documents that are loaded into the Vector Index
-    "chunked_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold",
+    "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
     "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
 }

--- a/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
@@ -94,8 +94,9 @@ destination_tables_config = {
     # Chunked documents that are loaded into the Vector Index
     "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
+    "vectorsearch_index_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold_index`",
 }
+destination_tables_config["vectorsearch_index_name"] = destination_tables_config["vectorsearch_index_table_name"].replace("`", "")
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/docx_uc_volume/02_poc_data_pipeline.py
+++ b/rag_app_sample_code/A_POC_app/docx_uc_volume/02_poc_data_pipeline.py
@@ -77,12 +77,6 @@ dbr_majorversion = int(spark.conf.get("spark.databricks.clusterUsageTags.sparkVe
 if dbr_majorversion >= 14:
   spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", True)
 
-# Helper function for display Delta Table URLs
-def get_table_url(table_fqdn):
-    split = table_fqdn.split(".")
-    browser_url = du.get_browser_hostname()
-    url = f"https://{browser_url}/explore/data/{split[0]}/{split[1]}/{split[2]}"
-    return url
 
 # COMMAND ----------
 
@@ -93,7 +87,7 @@ def get_table_url(table_fqdn):
 # COMMAND ----------
 
 # MAGIC %run ./00_config
-
+# MAGIC
 
 # COMMAND ----------
 
@@ -476,7 +470,7 @@ if create_index:
         embedding_model_endpoint_name=embedding_config['embedding_endpoint_name']
     )
 
-tag_delta_table(destination_tables_config["vectorsearch_index_name"], data_pipeline_config)
+tag_delta_table(destination_tables_config["vectorsearch_index_table_name"], data_pipeline_config)
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
@@ -88,13 +88,13 @@ data_pipeline_config = {
 # Names of the output Delta Tables tables & Vector Search index
 destination_tables_config = {
     # Staging table with the raw files & metadata
-    "raw_files_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_raw_files_bronze",
+    "raw_files_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_raw_files_bronze`",
     # Parsed documents
-    "parsed_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_parsed_docs_silver",
+    "parsed_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_parsed_docs_silver`",
     # Chunked documents that are loaded into the Vector Index
-    "chunked_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold",
+    "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
+    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_index",
 }
 
 # COMMAND ----------
@@ -173,7 +173,7 @@ rag_chain_config = {
             # The column name in the retriever's response that contains the returned chunk.
             "chunk_text": "chunked_text",
             # The template of the chunk returned by the retriever - used to format the chunk for presentation to the LLM.
-            "document_uri": "url",
+            "document_uri": "path",
         },
         # Prompt template used to format the retrieved information to present to the LLM to help in answering the user's question
         "chunk_template": "Passage: {chunk_text}\n",

--- a/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
@@ -94,8 +94,9 @@ destination_tables_config = {
     # Chunked documents that are loaded into the Vector Index
     "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
+    "vectorsearch_index_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold_index`",
 }
+destination_tables_config["vectorsearch_index_name"] = destination_tables_config["vectorsearch_index_table_name"].replace("`", "")
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
@@ -94,7 +94,7 @@ destination_tables_config = {
     # Chunked documents that are loaded into the Vector Index
     "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_index",
+    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
 }
 
 # COMMAND ----------

--- a/rag_app_sample_code/A_POC_app/html_uc_volume/02_poc_data_pipeline.py
+++ b/rag_app_sample_code/A_POC_app/html_uc_volume/02_poc_data_pipeline.py
@@ -37,12 +37,6 @@ dbr_majorversion = int(spark.conf.get("spark.databricks.clusterUsageTags.sparkVe
 if dbr_majorversion >= 14:
   spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", True)
 
-# Helper function for display Delta Table URLs
-def get_table_url(table_fqdn):
-    split = table_fqdn.split(".")
-    browser_url = du.get_browser_hostname()
-    url = f"https://{browser_url}/explore/data/{split[0]}/{split[1]}/{split[2]}"
-    return url
 
 # COMMAND ----------
 
@@ -435,7 +429,7 @@ if create_index:
         embedding_model_endpoint_name=embedding_config['embedding_endpoint_name']
     )
 
-tag_delta_table(destination_tables_config["vectorsearch_index_name"], data_pipeline_config)
+tag_delta_table(destination_tables_config["vectorsearch_index_table_name"], data_pipeline_config)
 mlflow.log_input(mlflow.data.load_delta(table_name=destination_tables_config.get("chunked_docs_table_name")), context="chunked_docs")
 
 # COMMAND ----------

--- a/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
@@ -88,11 +88,11 @@ data_pipeline_config = {
 # Names of the output Delta Tables tables & Vector Search index
 destination_tables_config = {
     # Staging table with the raw files & metadata
-    "raw_files_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_raw_files_bronze",
+    "raw_files_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_raw_files_bronze`",
     # Parsed documents
-    "parsed_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_parsed_docs_silver",
+    "parsed_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_parsed_docs_silver`",
     # Chunked documents that are loaded into the Vector Index
-    "chunked_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold",
+    "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
     "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
 }

--- a/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
@@ -94,8 +94,9 @@ destination_tables_config = {
     # Chunked documents that are loaded into the Vector Index
     "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
+    "vectorsearch_index_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold_index`",
 }
+destination_tables_config["vectorsearch_index_name"] = destination_tables_config["vectorsearch_index_table_name"].replace("`", "")
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/pdf_uc_volume/02_poc_data_pipeline.py
+++ b/rag_app_sample_code/A_POC_app/pdf_uc_volume/02_poc_data_pipeline.py
@@ -419,11 +419,13 @@ if create_index:
     print("Embedding docs & creating Vector Search Index, this can take 15 minutes or much longer if you have a larger number of documents.")
     print(f'Check status at: {get_table_url(destination_tables_config["vectorsearch_index_name"])}')
 
+    source_table_name = destination_tables_config["chunked_docs_table_name"].replace("`", "")
+
     vsc.create_delta_sync_index_and_wait(
         endpoint_name=VECTOR_SEARCH_ENDPOINT,
         index_name=destination_tables_config["vectorsearch_index_name"],
         primary_key="chunk_id",
-        source_table_name=destination_tables_config["chunked_docs_table_name"],
+        source_table_name=source_table_name,
         pipeline_type=vectorsearch_config['pipeline_type'],
         embedding_source_column="chunked_text",
         embedding_model_endpoint_name=embedding_config['embedding_endpoint_name']

--- a/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
@@ -97,11 +97,11 @@ data_pipeline_config = {
 # Names of the output Delta Tables tables & Vector Search index
 destination_tables_config = {
     # Staging table with the raw files & metadata
-    "raw_files_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_raw_files_bronze",
+    "raw_files_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_raw_files_bronze`",
     # Parsed documents
-    "parsed_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_parsed_docs_silver",
+    "parsed_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_parsed_docs_silver`",
     # Chunked documents that are loaded into the Vector Index
-    "chunked_docs_table_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold",
+    "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
     "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
 }

--- a/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
@@ -103,8 +103,9 @@ destination_tables_config = {
     # Chunked documents that are loaded into the Vector Index
     "chunked_docs_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold`",
     # Destination Vector Index
-    "vectorsearch_index_name": f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}_poc_chunked_docs_gold_index",
+    "vectorsearch_index_table_name": f"`{UC_CATALOG}`.`{UC_SCHEMA}`.`{RAG_APP_NAME}_poc_chunked_docs_gold_index`",
 }
+destination_tables_config["vectorsearch_index_name"] = destination_tables_config["vectorsearch_index_table_name"].replace("`", "")
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/pptx_uc_volume/02_poc_data_pipeline.py
+++ b/rag_app_sample_code/A_POC_app/pptx_uc_volume/02_poc_data_pipeline.py
@@ -77,12 +77,6 @@ dbr_majorversion = int(spark.conf.get("spark.databricks.clusterUsageTags.sparkVe
 if dbr_majorversion >= 14:
   spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", True)
 
-# Helper function for display Delta Table URLs
-def get_table_url(table_fqdn):
-    split = table_fqdn.split(".")
-    browser_url = du.get_browser_hostname()
-    url = f"https://{browser_url}/explore/data/{split[0]}/{split[1]}/{split[2]}"
-    return url
 
 # COMMAND ----------
 
@@ -578,7 +572,7 @@ if create_index:
         embedding_model_endpoint_name=embedding_config['embedding_endpoint_name']
     )
 
-tag_delta_table(destination_tables_config["vectorsearch_index_name"], data_pipeline_config)
+tag_delta_table(destination_tables_config["vectorsearch_index_table_name"], data_pipeline_config)
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/z_shared_utilities.py
+++ b/rag_app_sample_code/A_POC_app/z_shared_utilities.py
@@ -29,3 +29,10 @@ def tag_delta_table(table_fqn, config):
     for sql in sqls:
         # print(sql)
         spark.sql(sql)
+
+# Helper function for display Delta Table URLs
+def get_table_url(table_fqdn):
+    split = table_fqdn.replace('`', '').split(".")
+    browser_url = du.get_browser_hostname()
+    url = f"https://{browser_url}/explore/data/{split[0]}/{split[1]}/{split[2]}"
+    return url


### PR DESCRIPTION
This PR fixed the use of catalog names containing the `-` character.
It also fixes the column name mismatch for HTML document index (the URI column is called `path` since it loads the HTML documents from a UC volume).