### PR TITLE
Fixes to 00_config for extra 'install' in pip statement

### DIFF
--- a/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/docx_uc_volume/00_config.py
@@ -3,7 +3,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -U -qqqq install pyyaml mlflow mlflow-skinny
+# MAGIC %pip install -U -qqqq pyyaml mlflow mlflow-skinny
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/html_uc_volume/00_config.py
@@ -3,7 +3,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -U -qqqq install pyyaml mlflow mlflow-skinny
+# MAGIC %pip install -U -qqqq pyyaml mlflow mlflow-skinny
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pdf_uc_volume/00_config.py
@@ -3,7 +3,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -U -qqqq install pyyaml mlflow mlflow-skinny
+# MAGIC %pip install -U -qqqq pyyaml mlflow mlflow-skinny
 
 # COMMAND ----------
 

--- a/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
+++ b/rag_app_sample_code/A_POC_app/pptx_uc_volume/00_config.py
@@ -3,7 +3,7 @@
 
 # COMMAND ----------
 
-# MAGIC %pip install -U -qqqq install pyyaml mlflow mlflow-skinny
+# MAGIC %pip install -U -qqqq pyyaml mlflow mlflow-skinny
 
 # COMMAND ----------
 


### PR DESCRIPTION
All affected notebooks for this PR include an extra 'install', which leads to error:

`ERROR: Could not find a version that satisfies the requirement install (from versions: none)
ERROR: No matching distribution found for install
CalledProcessError: Command 'pip --disable-pip-version-check install -U -qqqq install databricks-sdk mlflow mlflow-skinny' returned non-zero exit status 1.`

This PR removes the extra word so pip commands run successfully. 