### PR TITLE
Fixed escape character in config

### DIFF
--- a/quick_start_demo/Mosaic-AI-Agents-10-Minute-Demo.py
+++ b/quick_start_demo/Mosaic-AI-Agents-10-Minute-Demo.py
@@ -96,7 +96,7 @@ UC_SCHEMA = f'rag_{user_name}'
 UC_SCHEMA = "10_mins"
 
 # UC Model name where the POC chain is logged
-UC_MODEL_NAME = f"`{UC_CATALOG}`.`{UC_SCHEMA}`.{user_name}_agent_quick_start"
+UC_MODEL_NAME = f"{UC_CATALOG}.{UC_SCHEMA}.{user_name}_agent_quick_start"
 
 # Vector Search endpoint where index is loaded
 # If this does not exist, it will be created

--- a/rag_app_sample_code/00_global_config.py
+++ b/rag_app_sample_code/00_global_config.py
@@ -38,7 +38,7 @@ UC_CATALOG = f'{user_name}_catalog'
 UC_SCHEMA = f'rag_{user_name}'
 
 ## UC Model name where the POC chain is logged
-UC_MODEL_NAME = f"`{UC_CATALOG}`.`{UC_SCHEMA}`.{RAG_APP_NAME}"
+UC_MODEL_NAME = f"{UC_CATALOG}.{UC_SCHEMA}.{RAG_APP_NAME}"
 
 # Vector Search endpoint where index is loaded
 # If this does not exist, it will be created


### PR DESCRIPTION
Removed escape characters from UC_MODEL_NAME, because escape characters are only needed for table names.