### PR TITLE
Update CD to use github artifact uploadv4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,7 +42,7 @@ jobs:
           cp ./genai_cookbook/10-min-demo/mosaic-ai-agents-demo-dbx-notebook.html ./genai_cookbook/_build/html/10-min-demo/mosaic-ai-agents-demo-dbx-notebook.html
       # Upload the book's HTML as an artifact
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: "genai_cookbook/_build/html"
       # Deploy the book's HTML to GitHub Pages


### PR DESCRIPTION
### Related Issues/PRs
ran into: https://github.com/databricks/genai-cookbook/actions/runs/13710618710
because of: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

updating to use v4


### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?
<!-- Manual testing is currently required to merge pull requests. Please include a screenshot/video proof of manual testing of changes
 -->
